### PR TITLE
feat!: unify user identity across members, board, and auth — gate login to board members

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -6,6 +6,7 @@ interface AuthContextType {
   user: User | null;
   session: Session | null;
   isAdmin: boolean;
+  isBoardMember: boolean;
   loading: boolean;
   signIn: (email: string, password: string) => Promise<{ error: Error | null }>;
   signUp: (email: string, password: string) => Promise<{ error: Error | null }>;
@@ -18,6 +19,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isBoardMember, setIsBoardMember] = useState(false);
   const [loading, setLoading] = useState(true);
 
   const checkAdmin = async (userId: string) => {
@@ -30,6 +32,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setIsAdmin(!!data);
   };
 
+  const checkBoardMember = async (userId: string) => {
+    const { data } = await supabase
+      .from("board_members")
+      .select("id")
+      .eq("user_id", userId)
+      .maybeSingle();
+    setIsBoardMember(!!data);
+  };
+
+  const checkRoles = async (userId: string) => {
+    await Promise.all([checkAdmin(userId), checkBoardMember(userId)]);
+  };
+
   useEffect(() => {
     let mounted = true;
 
@@ -38,11 +53,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setSession(session);
         setUser(session?.user ?? null);
         if (session?.user) {
-          checkAdmin(session.user.id).then(() => {
+          checkRoles(session.user.id).then(() => {
             if (mounted) setLoading(false);
           });
         } else {
           setIsAdmin(false);
+          setIsBoardMember(false);
           setLoading(false);
         }
       }
@@ -52,7 +68,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       setSession(session);
       setUser(session?.user ?? null);
       if (session?.user) {
-        await checkAdmin(session.user.id);
+        await checkRoles(session.user.id);
       }
       if (mounted) setLoading(false);
     });
@@ -82,7 +98,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ user, session, isAdmin, loading, signIn, signUp, signOut }}>
+    <AuthContext.Provider value={{ user, session, isAdmin, isBoardMember, loading, signIn, signUp, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -53,32 +53,46 @@ export type Database = {
           created_at: string
           email: string | null
           id: string
+          member_id: string | null
           name: string
           role: string
           sort_order: number | null
           updated_at: string
+          user_id: string | null
         }
         Insert: {
           bio?: string | null
           created_at?: string
           email?: string | null
           id?: string
+          member_id?: string | null
           name: string
           role: string
           sort_order?: number | null
           updated_at?: string
+          user_id?: string | null
         }
         Update: {
           bio?: string | null
           created_at?: string
           email?: string | null
           id?: string
+          member_id?: string | null
           name?: string
           role?: string
           sort_order?: number | null
           updated_at?: string
+          user_id?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "board_members_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: true
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          }
+        ]
       }
       gallery_images: {
         Row: {
@@ -119,6 +133,7 @@ export type Database = {
           phone: string | null
           registered_at: string
           status: string
+          user_id: string | null
         }
         Insert: {
           date_of_birth?: string | null
@@ -131,6 +146,7 @@ export type Database = {
           phone?: string | null
           registered_at?: string
           status?: string
+          user_id?: string | null
         }
         Update: {
           date_of_birth?: string | null
@@ -143,6 +159,7 @@ export type Database = {
           phone?: string | null
           registered_at?: string
           status?: string
+          user_id?: string | null
         }
         Relationships: []
       }
@@ -211,6 +228,12 @@ export type Database = {
       has_role: {
         Args: {
           _role: Database["public"]["Enums"]["app_role"]
+          _user_id: string
+        }
+        Returns: boolean
+      }
+      is_board_member: {
+        Args: {
           _user_id: string
         }
         Returns: boolean

--- a/src/pages/AdminBoard.tsx
+++ b/src/pages/AdminBoard.tsx
@@ -12,6 +12,15 @@ interface BoardMember {
   email: string | null;
   bio: string | null;
   sort_order: number;
+  member_id: string | null;
+  user_id: string | null;
+}
+
+interface MemberOption {
+  id: string;
+  first_name: string;
+  last_name: string | null;
+  email: string;
 }
 
 const AdminBoard = () => {
@@ -19,10 +28,11 @@ const AdminBoard = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
   const [members, setMembers] = useState<BoardMember[]>([]);
+  const [memberOptions, setMemberOptions] = useState<MemberOption[]>([]);
   const [fetching, setFetching] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editId, setEditId] = useState<string | null>(null);
-  const [form, setForm] = useState({ name: "", role: "", email: "", bio: "", sort_order: 0 });
+  const [form, setForm] = useState({ name: "", role: "", email: "", bio: "", sort_order: 0, member_id: "" });
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
@@ -30,15 +40,19 @@ const AdminBoard = () => {
   }, [user, isAdmin, loading, navigate]);
 
   const fetchMembers = async () => {
-    const { data } = await supabase.from("board_members").select("*").order("sort_order");
-    setMembers(data ?? []);
+    const [boardRes, memberRes] = await Promise.all([
+      supabase.from("board_members").select("*").order("sort_order"),
+      supabase.from("members").select("id, first_name, last_name, email").eq("status", "approved").order("first_name"),
+    ]);
+    setMembers(boardRes.data ?? []);
+    setMemberOptions(memberRes.data ?? []);
     setFetching(false);
   };
 
   useEffect(() => { if (isAdmin) fetchMembers(); }, [isAdmin]);
 
   const resetForm = () => {
-    setForm({ name: "", role: "", email: "", bio: "", sort_order: 0 });
+    setForm({ name: "", role: "", email: "", bio: "", sort_order: 0, member_id: "" });
     setEditId(null);
     setShowForm(false);
   };
@@ -56,6 +70,7 @@ const AdminBoard = () => {
       email: form.email.trim() || null,
       bio: form.bio.trim() || null,
       sort_order: form.sort_order,
+      member_id: form.member_id || null,
     };
     if (editId) {
       const { error } = await supabase.from("board_members").update(payload).eq("id", editId);
@@ -79,7 +94,7 @@ const AdminBoard = () => {
 
   const startEdit = (m: BoardMember) => {
     setEditId(m.id);
-    setForm({ name: m.name, role: m.role, email: m.email ?? "", bio: m.bio ?? "", sort_order: m.sort_order });
+    setForm({ name: m.name, role: m.role, email: m.email ?? "", bio: m.bio ?? "", sort_order: m.sort_order, member_id: m.member_id ?? "" });
     setShowForm(true);
   };
 
@@ -116,6 +131,32 @@ const AdminBoard = () => {
               <input value={form.email} onChange={e => setForm(p => ({ ...p, email: e.target.value }))} className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
             </div>
             <div>
+              <label className="block text-sm font-medium text-foreground mb-1">Link to Member</label>
+              <select
+                value={form.member_id}
+                onChange={e => {
+                  const selectedMember = memberOptions.find(mo => mo.id === e.target.value);
+                  setForm(p => ({
+                    ...p,
+                    member_id: e.target.value,
+                    ...(selectedMember ? {
+                      name: `${selectedMember.first_name} ${selectedMember.last_name ?? ""}`.trim(),
+                      email: selectedMember.email,
+                    } : {}),
+                  }));
+                }}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <option value="">— No linked member —</option>
+                {memberOptions.map(mo => (
+                  <option key={mo.id} value={mo.id}>
+                    {mo.first_name} {mo.last_name ?? ""} ({mo.email})
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground mt-1">Linking a member shares the same identity across members, board, and auth.</p>
+            </div>
+            <div>
               <label className="block text-sm font-medium text-foreground mb-1">Bio</label>
               <textarea value={form.bio} onChange={e => setForm(p => ({ ...p, bio: e.target.value }))} rows={3} className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
             </div>
@@ -140,6 +181,11 @@ const AdminBoard = () => {
                 <h3 className="font-display text-lg text-foreground">{m.name}</h3>
                 <p className="text-sm gold-accent font-display">{m.role}</p>
                 {m.bio && <p className="text-sm text-muted-foreground mt-1">{m.bio}</p>}
+                {m.member_id && (
+                  <p className="text-xs text-primary/70 mt-1 flex items-center gap-1">
+                    ✓ Linked to member
+                  </p>
+                )}
               </div>
               <div className="flex gap-2 shrink-0">
                 <button onClick={() => startEdit(m)} className="p-2 rounded hover:bg-muted transition"><Pencil size={16} className="text-muted-foreground" /></button>

--- a/src/pages/AdminMembers.tsx
+++ b/src/pages/AdminMembers.tsx
@@ -14,6 +14,7 @@ interface Member {
   experience_level: string | null;
   registered_at: string;
   status: string;
+  user_id: string | null;
 }
 
 interface UserRole {
@@ -38,7 +39,7 @@ const AdminMembers = () => {
 
   const fetchData = async () => {
     const [membersRes, rolesRes] = await Promise.all([
-      supabase.from("members").select("id, first_name, last_name, email, phone, experience_level, registered_at, status").order("registered_at", { ascending: false }),
+      supabase.from("members").select("id, first_name, last_name, email, phone, experience_level, registered_at, status, user_id").order("registered_at", { ascending: false }),
       supabase.from("user_roles").select("user_id, role"),
     ]);
     setMembers(membersRes.data ?? []);
@@ -158,13 +159,14 @@ const AdminMembers = () => {
                   <th className="text-left px-4 py-3 font-display text-foreground">Name</th>
                   <th className="text-left px-4 py-3 font-display text-foreground">Email</th>
                   <th className="text-left px-4 py-3 font-display text-foreground">Level</th>
+                  <th className="text-left px-4 py-3 font-display text-foreground">Linked</th>
                   <th className="text-left px-4 py-3 font-display text-foreground">Applied</th>
                   <th className="text-right px-4 py-3 font-display text-foreground">Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {filtered.length === 0 && (
-                  <tr><td colSpan={5} className="text-center py-8 text-muted-foreground">No {tab} members.</td></tr>
+                  <tr><td colSpan={6} className="text-center py-8 text-muted-foreground">No {tab} members.</td></tr>
                 )}
                 {filtered.map((m) => (
                   <tr key={m.id} className="border-b border-border last:border-0 hover:bg-muted/20 transition">
@@ -184,6 +186,13 @@ const AdminMembers = () => {
                         <input value={editForm.experience_level} onChange={e => setEditForm(p => ({ ...p, experience_level: e.target.value }))} className="w-24 rounded border border-input bg-background px-1.5 py-0.5 text-xs" placeholder="Level" />
                       ) : (
                         <span className="text-muted-foreground">{m.experience_level ?? "—"}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      {m.user_id ? (
+                        <span className="text-xs text-primary" title={m.user_id}>✓ Auth</span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
                       )}
                     </td>
                     <td className="px-4 py-3 text-muted-foreground">

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -21,20 +21,26 @@ const Auth = () => {
 
   useEffect(() => {
     if (!user) return;
-    // Check if user is a registered member
-    const checkMembership = async () => {
-      const { data } = await supabase
+    // Check if user is a registered member AND a board member
+    const checkAccess = async () => {
+      // 1. Check membership
+      const { data: member } = await supabase
         .from("members")
-        .select("id, status")
+        .select("id, status, user_id")
         .eq("email", user.email ?? "")
         .maybeSingle();
-      if (!data) {
+
+      if (!member) {
         toast({
           title: "Access denied",
           description: "You must be a registered member to log in. Please register first.",
           variant: "destructive",
         });
-      } else if (data.status !== "approved") {
+        await supabase.auth.signOut();
+        return;
+      }
+
+      if (member.status !== "approved") {
         toast({
           title: "Pending approval",
           description: "Your membership is still pending admin approval.",
@@ -43,9 +49,43 @@ const Auth = () => {
         await supabase.auth.signOut();
         return;
       }
+
+      // 2. Link user_id to member record if not already linked
+      if (!member.user_id) {
+        await supabase
+          .from("members")
+          .update({ user_id: user.id })
+          .eq("id", member.id);
+      }
+
+      // 3. Check board membership
+      const { data: boardMember } = await supabase
+        .from("board_members")
+        .select("id, user_id, member_id")
+        .eq("member_id", member.id)
+        .maybeSingle();
+
+      if (!boardMember) {
+        toast({
+          title: "Access restricted",
+          description: "Only board members can log in to the management area.",
+          variant: "destructive",
+        });
+        await supabase.auth.signOut();
+        return;
+      }
+
+      // 4. Link user_id to board_member record if not already linked
+      if (!boardMember.user_id) {
+        await supabase
+          .from("board_members")
+          .update({ user_id: user.id })
+          .eq("id", boardMember.id);
+      }
+
       navigate("/", { replace: true });
     };
-    checkMembership();
+    checkAccess();
   }, [user, navigate, toast]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -58,7 +98,7 @@ const Auth = () => {
     setSubmitting(true);
 
     if (isLogin) {
-      // Check membership before attempting login
+      // Check membership + board membership before attempting login
       const { data: member } = await supabase
         .from("members")
         .select("id, status")
@@ -70,7 +110,10 @@ const Auth = () => {
           description: "You must be a registered member to log in. Please register first via the Join Us page.",
           variant: "destructive",
         });
-      } else if (member.status !== "approved") {
+        setSubmitting(false);
+        return;
+      }
+      if (member.status !== "approved") {
         toast({
           title: "Pending approval",
           description: "Your membership is still pending admin approval. Please wait for confirmation.",
@@ -79,6 +122,23 @@ const Auth = () => {
         setSubmitting(false);
         return;
       }
+
+      // Check board membership by member_id
+      const { data: boardMember } = await supabase
+        .from("board_members")
+        .select("id")
+        .eq("member_id", member.id)
+        .maybeSingle();
+      if (!boardMember) {
+        toast({
+          title: "Access restricted",
+          description: "Only board members can log in. Contact the club administration if you believe this is an error.",
+          variant: "destructive",
+        });
+        setSubmitting(false);
+        return;
+      }
+
       const { error } = await signIn(email, password);
       setSubmitting(false);
       if (error) {
@@ -102,7 +162,7 @@ const Auth = () => {
           {isLogin ? "Board Login" : "Create Account"}
         </h1>
         <p className="text-sm text-muted-foreground text-center mb-8">
-          {isLogin ? "Sign in to manage the club (members only)" : "Register a new board account"}
+          {isLogin ? "Sign in to manage the club (board members only)" : "Register a new board account"}
         </p>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>

--- a/supabase/migrations/20260221120000_unified_user_identity.sql
+++ b/supabase/migrations/20260221120000_unified_user_identity.sql
@@ -1,0 +1,56 @@
+-- =============================================================================
+-- Unified User Identity
+-- Links members and board_members to auth.users via shared foreign keys
+-- Restricts login to board members only
+-- =============================================================================
+
+-- 1. Add user_id column to members table (links to the Supabase auth user)
+ALTER TABLE public.members
+  ADD COLUMN user_id UUID UNIQUE REFERENCES auth.users(id) ON DELETE SET NULL;
+
+-- 2. Add member_id column to board_members (links a board seat to a member)
+ALTER TABLE public.board_members
+  ADD COLUMN member_id UUID UNIQUE REFERENCES public.members(id) ON DELETE SET NULL;
+
+-- 3. Add user_id column to board_members for direct auth lookup
+ALTER TABLE public.board_members
+  ADD COLUMN user_id UUID UNIQUE REFERENCES auth.users(id) ON DELETE SET NULL;
+
+-- 4. Create index for fast lookups
+CREATE INDEX idx_members_user_id ON public.members(user_id);
+CREATE INDEX idx_members_email ON public.members(email);
+CREATE INDEX idx_board_members_member_id ON public.board_members(member_id);
+CREATE INDEX idx_board_members_user_id ON public.board_members(user_id);
+
+-- 5. Back-fill: link existing board_members to members by matching email
+UPDATE public.board_members bm
+SET member_id = m.id
+FROM public.members m
+WHERE lower(bm.email) = lower(m.email);
+
+-- 6. Helper function: check if a user is a board member
+CREATE OR REPLACE FUNCTION public.is_board_member(_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.board_members
+    WHERE user_id = _user_id
+  )
+$$;
+
+-- 7. Update members RLS: members can view their own record regardless of status
+CREATE POLICY "Members can view own record"
+  ON public.members FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+-- 8. Allow authenticated members to update their own non-status fields
+CREATE POLICY "Members can update own profile"
+  ON public.members FOR UPDATE
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary

Unifies user identity across the `members`, `board_members`, and `auth.users` tables using shared foreign key references. Restricts login to **board members only**.

## Problem

Previously:
- `members.id`, `board_members.id`, and `auth.users.id` were all independent UUIDs with no foreign key relationships
- Cross-table lookups relied on fragile **email matching** rather than ID references
- Any registered + approved member could log in — there was no board membership gate

## Solution

### Database Changes (new migration)

| Change | Detail |
|---|---|
| `members.user_id` | New `UUID` FK → `auth.users(id)`, auto-linked on first login |
| `board_members.member_id` | New `UUID` FK → `members(id)`, set via Admin Board UI |
| `board_members.user_id` | New `UUID` FK → `auth.users(id)`, auto-linked on first login |
| `is_board_member()` | New SQL function for fast board membership checks |
| Indexes | On `members(user_id)`, `members(email)`, `board_members(member_id)`, `board_members(user_id)` |
| RLS policies | Members can view/update own record |
| Back-fill | Existing `board_members ↔ members` linked by email match |

### Identity Flow

```
auth.users(id) ←── members.user_id
                    members.id ←── board_members.member_id
auth.users(id) ←── board_members.user_id
```

All three tables can now be joined on a shared user identity.

### Auth Flow Changes

```
Login → Check member exists + approved → Check board_members has matching member_id → Allow sign-in
                                                                                   → Auto-link user_id to both tables
```

### Frontend Changes

| File | Change |
|---|---|
| `useAuth.tsx` | Added `isBoardMember` to AuthContext; checks `board_members.user_id` |
| `Auth.tsx` | Pre-login and post-login now verify board membership; auto-links `user_id` |
| `AdminBoard.tsx` | New "Link to Member" dropdown to connect board seats to approved members |
| `AdminMembers.tsx` | Shows "Linked" auth status column in member table |
| `types.ts` | Updated with `user_id`, `member_id` columns, `is_board_member` function, relationships |

## Breaking Change

⚠️ Only board members can now log in at `/auth`. Regular approved members without a board seat will be denied access.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Database migration